### PR TITLE
fix(rules): fix Any of rule to php 8

### DIFF
--- a/src/Rules/AnyOf.php
+++ b/src/Rules/AnyOf.php
@@ -45,7 +45,7 @@ class AnyOf extends AbstractRule
         $len = strlen($this->rule);
         $char = $context->value();
         for ($i = 0; $i < $len; ++$i) {
-            if ($char === $this->rule{$i}) {
+            if ($char === $this->rule[$i]) {
                 $result = new Result($this->name);
                 $result->setValue($char, $index);
                 $this->action($result);


### PR DESCRIPTION
On php 8 array and string access to index using {} no longer supported. Changing to [].